### PR TITLE
chore(ci): fix CI failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ install:
 - rustup default nightly
 - rustup component add clippy
 - cargo install grcov rust-covfix
-before_script:
-- cd md_designer
 jobs:
   include:
   - stage: test and format check
@@ -17,6 +15,7 @@ jobs:
     dist: focal
     before_script:
       - rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
+      - cd md_designer
     script:
       - cargo test --features excel
       - cargo clippy --features excel -Z unstable-options -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,26 @@ language: rust
 dist: focal
 rust:
 - nightly
-cache:
-  cargo: true
 install:
+- rustup install stable
 - rustup update
-- rustup component add clippy rustfmt
+- rustup default nightly
+- rustup component add clippy
 - cargo install grcov rust-covfix
 before_script:
 - cd md_designer
 jobs:
   include:
-  - stage: unit tests
+  - stage: test and format check
+    os: linux
+    dist: focal
+    before_script:
+      - rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
     script:
-    - cargo test --features excel
-  - stage: check rustfmt style && run clippy
-    script:
-    - cargo clippy --features excel -Z unstable-options -- -D warnings
-    - cargo fmt --all -- --check
-  - stage: coverage sending
-    script:
-    - bash coverage.sh ontravis sendcov
+      - cargo test
+      - cargo clippy -Z unstable-options -- -D warnings
+      - cargo +stable fmt --all -- --check
+      - bash coverage.sh ontravis sendcov
 env:
   global:
     secure: zOr7Re70susrc/q7/nVwcorOexfBFBuJx/dztkt0VwXfAxTic3SlK38wMBJ9vOH+OOMuqYp9mjhKjJaBMsTw2wja93dh6KzaEiUsb9RQjBSdZlutWfrlDhkZSLr5dZjRzB2rnaIYKdaKCDEz4TVtoGAeTjuNSiLxxE0l6RFawl+ekhKqCYmbyyUzZdCQPPS0lthcJxhRnLZmeY1ojM5dbdgBubHhQ9ksCPVn+1GlwO8fkW8RlNgeWbtim1EsIMmsozRDGYmyPtWKYjJVBey49iindZnmSzaKJ0ilbQX2HwjYshaD+kauOXgQz/wZd0FwRdiqtvDpzwSkW+SGVYcs59dKJoDXVpiqypTWJ0k+jRGEdeR0Kq40sKmPsjk5yNMQr/Sy5fLDYHWnUAW9VUzZdFIc8lKZwXU/ez3QbCErfYW4RVaKHyrxjkQ9rRbSjTCRXHDILs/nF9E58NP/AV6noPkygCyzHhArvU1/q+DB/rg4q1H6XqTsX5LFjJzbh6hJnq4PHmEmhIVC5XIGe9rnLyD7VPdkwlsUXWYnQSnnSfc7m0vyZ8sqonR/r/d09kIHyUzZWOEhnfssB1IEdlKsTvL60xdDYmUX0E1/v98cuu4TwgHYszOSMZwGuTyCfkg+FCMTROmEQG/QZXHZ/uDTgCoEGLWrV09WiPWl0xEO9ms=

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
     before_script:
       - rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
     script:
-      - cargo test
-      - cargo clippy -Z unstable-options -- -D warnings
+      - cargo test --features excel
+      - cargo clippy --features excel -Z unstable-options -- -D warnings
       - cargo +stable fmt --all -- --check
       - bash coverage.sh ontravis sendcov
 env:


### PR DESCRIPTION
fix #26

It seems that component `rustfmt` is no longer included in the nightly toolchain.
So the stable `rustfmt` should be used to check the code format. And also, Rust's cache tend to be large, so I disabled the cache feature once.