### PR TITLE
chore(ci): fix broken build from forked PRs

### DIFF
--- a/md_designer/coverage.sh
+++ b/md_designer/coverage.sh
@@ -22,5 +22,9 @@ if [ $# = 0 ] || [ "$1" != "ontravis" ]; then
 fi
 
 if [ $# -gt 1 ] && [ "$2" = "sendcov" ]; then
-    bash <(curl -s https://codecov.io/bash) -f lcov.info -t "${CODECOV_TOKEN}"
+    if [ -z "${CODECOV_TOKEN+x}" ]; then
+        echo "environment variable CODECOV_TOKEN is empty, skipping sending coverage to codecov..."
+    else
+        bash <(curl -s https://codecov.io/bash) -f lcov.info -t "${CODECOV_TOKEN}"
+    fi
 fi


### PR DESCRIPTION
fix #30 

CI build from forked PR fails because secret variable isn't available to such builds. So It should be checked if CODECOV_TOKEN variable is defined, if undefined, skip sending coverage to codecov.