### PR TITLE
feat(cli): support output filename

### DIFF
--- a/md_designer/src/bin/main.rs
+++ b/md_designer/src/bin/main.rs
@@ -7,8 +7,7 @@ use chrono::Local;
 use clap::{crate_authors, crate_description, crate_name, crate_version, App as ClapApp, Arg};
 use log::{debug, info};
 
-use md_designer::app::App;
-use md_designer::rule::Rule;
+use md_designer::{app::App, rule::Rule, utils::get_output_filename};
 
 fn main() -> Result<()> {
     // setup clap
@@ -25,6 +24,12 @@ fn main() -> Result<()> {
             Arg::with_name("conf_path")
                 .required(true)
                 .help("config file path (.yml)"),
+        )
+        .arg(
+            Arg::with_name("output_filename")
+                .short("o")
+                .takes_value(true)
+                .help("output file name. '.xlsx' is optional."),
         )
         .arg(
             Arg::with_name("verbose")
@@ -75,10 +80,14 @@ fn main() -> Result<()> {
     let rule = Rule::marshal(&cfg_text)?;
 
     let app = App::new(
-        path.file_stem()
-            .with_context(|| "Input file path is malformed")?
-            .to_str()
-            .unwrap(),
+        get_output_filename(
+            clap.value_of("output_filename").unwrap_or(
+                path.file_stem()
+                    .with_context(|| "Input file path is malformed")?
+                    .to_str()
+                    .unwrap(),
+            ),
+        )?,
         &input_text,
         rule,
     )?;

--- a/md_designer/src/utils.rs
+++ b/md_designer/src/utils.rs
@@ -1,3 +1,5 @@
+use anyhow::{anyhow, Result};
+use log::info;
 use pulldown_cmark::Tag;
 
 use crate::constant::CUSTOM_PREFIX_KEY;
@@ -31,4 +33,34 @@ pub fn custom_prefix_to_key(text_with_custom_prefix: Option<&str>) -> Option<Str
 
 pub fn get_custom_prefix_end_idx() -> usize {
     format!("!!!{}{}", CUSTOM_PREFIX_KEY.clone(), "a").len() + 1
+}
+
+pub fn get_output_filename(filename: &str) -> Result<&str> {
+    if filename.is_empty() {
+        Err(anyhow!("output filename is empty."))
+    } else {
+        let result = if let Some(stripped) = filename.strip_suffix(".xlsx") {
+            stripped
+        } else {
+            filename
+        };
+        info!("output filename without extension: {}", result);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_output_filename() {
+        assert_eq!("output", get_output_filename("output").unwrap());
+        assert_eq!("output", get_output_filename("output.xlsx").unwrap());
+    }
+
+    #[test]
+    fn test_get_output_filename_error() {
+        assert!(get_output_filename("").is_err());
+    }
 }


### PR DESCRIPTION
fix #16 

Add argument '-o (output filename)'. Support both filename without extension and with it.